### PR TITLE
ordered: optimize allocations in Append

### DIFF
--- a/code.go
+++ b/code.go
@@ -169,6 +169,7 @@ import (
 	"fmt"
 	"math"
 	"math/bits"
+	"reflect"
 )
 
 // opcode is the type byte for an encoded value.
@@ -376,7 +377,8 @@ func Append(enc []byte, list ...any) []byte {
 	for _, x := range list {
 		switch x := x.(type) {
 		default:
-			panic(fmt.Sprintf("ordered: invalid type %T", x))
+			t := reflect.TypeOf(x)
+			panic(fmt.Sprintf("ordered: invalid type %s", t))
 		case string:
 			enc = appendString(enc, x, 0)
 		case Reverse[string]:

--- a/code_test.go
+++ b/code_test.go
@@ -675,3 +675,19 @@ func TestDecodeNil(t *testing.T) {
 		t.Errorf("Decode(enc, nil, nil, &x) = %v, x=%d; want nil, x=3", err, x)
 	}
 }
+
+func BenchmarkAppend(b *testing.B) {
+	b.Run("Simple", func(b *testing.B) {
+		b.ReportAllocs()
+		buf := make([]byte, 256)
+		for i := 0; i < b.N; i++ {
+			var (
+				i1, i2 int     = 1, 2
+				u      uint64  = 256
+				f      float64 = 1.61
+				s              = "abc"
+			)
+			Append(buf[:0], i1, i2, i2, i2, u, u, u, f, s)
+		}
+	})
+}


### PR DESCRIPTION
The '%T' format specifier was causing extra allocations in the Append function, even outside the default branch.